### PR TITLE
Integrate recent fixes with cached helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # NozzleSim
 Uses the method of characteristics to simulate supersonic flow in an axisymmetric nozzle, and use Busemann's method to construct a nozzle producing isentropic flow according to certain parameters
+
+## Reference case verification
+
+The script `reference_cases.py` prints a few simple characteristic angles and
+compares them with values computed by hand using textbook formulas.  Each case
+computes the propagation angle for a single expansion (bend) and shows the
+difference between the analytical result and the value returned by the code.
+Run it with `python3 reference_cases.py`.

--- a/helperfuncs.py
+++ b/helperfuncs.py
@@ -1,4 +1,5 @@
 import math as m
+from functools import lru_cache
 
 
 sign = lambda x: m.copysign(1, x)
@@ -6,6 +7,7 @@ sign = lambda x: m.copysign(1, x)
 def machangle(mach):
     return m.asin(1/mach)
 
+@lru_cache(maxsize=None)
 def calcv(gamma, mach1, mach2):
     k = m.sqrt((gamma + 1)/(gamma - 1))  # dunno what actual significance of this is
     alpha1 = machangle(mach1)  # first mach angle
@@ -30,6 +32,7 @@ def binarysearch(lowerbound, upperbound, target, steps, func):
     return val
 
 #  calcmach has been verified against the table, at least for gamma of 1.4
+@lru_cache(maxsize=None)
 def calcmach(gamma, mach1, angle, steps=30):
     if angle == 0:
         return 1
@@ -37,6 +40,7 @@ def calcmach(gamma, mach1, angle, steps=30):
     return binarysearch(1, 100, angle, steps, f)
 
 
+@lru_cache(maxsize=None)
 def calcshockemitangle(gamma, angle, mach1=-1.0, v1=-1.0):
     if mach1 == -1:
         mach1 = calcmach(gamma, 1, v1)
@@ -47,11 +51,13 @@ def calcshockemitangle(gamma, angle, mach1=-1.0, v1=-1.0):
     return abar + .5 * abs(angle)
 
 
+@lru_cache(maxsize=None)
 def calcvmax(gamma):
     k = m.sqrt((gamma + 1) / (gamma - 1))
     return m.degrees(m.pi/2 * (k - 1))
 
 
+@lru_cache(maxsize=None)
 def calcshockpropangle(gamma, v1, theta, turningangle):
     mach1 = calcmach(gamma, 1, v1)
     mach2 = calcmach(gamma, 1, v1 + abs(turningangle))
@@ -61,6 +67,7 @@ def calcshockpropangle(gamma, v1, theta, turningangle):
     return abar + theta - turningangle/2
 
 
+@lru_cache(maxsize=None)
 def alphadiff(gamma, v1, v2):
     mach1 = calcmach(gamma, 1, v1)
     mach2 = calcmach(gamma, 1, v2)
@@ -69,18 +76,22 @@ def alphadiff(gamma, v1, v2):
     return alpha1 - alpha2
 
 
+@lru_cache(maxsize=None)
 def calcarearatio(gamma, mach):
     return 1/mach * ((2 + (gamma - 1) * mach ** 2)/(gamma + 1)) ** (.5 * ((gamma + 1)/(gamma - 1)))
 
+@lru_cache(maxsize=None)
 def calcmachfromarearatio(gamma, ratio, steps=20):
     f = lambda mach: calcarearatio(gamma, mach)
     return binarysearch(1.1, 1000, ratio, steps, f)
 
+@lru_cache(maxsize=None)
 def shockangle(gamma, v, theta, turningangle):
     mach1 = calcmach(gamma, 1, v)
     alpha1 = m.degrees(machangle(mach1))
     return -sign(turningangle) * alpha1 + theta
 
+@lru_cache(maxsize=None)
 def shockprop(gamma, v, theta, turningangle):
     angle1 = shockangle(gamma, v, theta, turningangle)
     angle2 = shockangle(gamma, v + abs(turningangle), theta + turningangle, turningangle)

--- a/reference_cases.py
+++ b/reference_cases.py
@@ -1,0 +1,39 @@
+import math
+import helperfuncs as h
+
+
+def manual_prop_angle(gamma, v1, theta, delta):
+    """Return expected propagation angle of a characteristic after a bend."""
+    M1 = h.calcmach(gamma, 1, v1)
+    v2 = v1 + abs(delta)
+    M2 = h.calcmach(gamma, 1, v2)
+    mu1 = math.degrees(math.asin(1 / M1))
+    mu2 = math.degrees(math.asin(1 / M2))
+    theta1 = theta
+    theta2 = theta + delta
+    sign = 1 if delta < 0 else -1
+    return (theta1 + theta2) / 2 + sign * (mu1 + mu2) / 2
+
+
+def run_cases():
+    cases = [
+        dict(gamma=1.4, M1=2.0, theta=0.0, delta=-5.0),
+        dict(gamma=1.4, M1=3.0, theta=0.0, delta=10.0),
+        dict(gamma=1.4, M1=2.0, theta=15.0, delta=-3.0),
+    ]
+    for i, case in enumerate(cases, 1):
+        gamma = case['gamma']
+        v1 = h.calcv(gamma, 1, case['M1'])
+        theta = case['theta']
+        delta = case['delta']
+        code_angle = h.shockprop(gamma, v1, theta, delta)
+        manual_angle = manual_prop_angle(gamma, v1, theta, delta)
+        diff = code_angle - manual_angle
+        print(f"Case {i}: gamma={gamma}, M1={case['M1']}, theta={theta}, delta={delta}")
+        print(f"  computed: {code_angle:.6f}")
+        print(f"  manual:   {manual_angle:.6f}")
+        print(f"  diff:     {diff:.6g}\n")
+
+
+if __name__ == '__main__':
+    run_cases()

--- a/shockmesh.py
+++ b/shockmesh.py
@@ -55,7 +55,6 @@ class Mesh:
         if self.remainingangle <= 0:
             lastcheck = True
         while event is not None and self.x < stop:
-            print(self.x)
             self.handleevent(event)
             event = self.firstevent(self.activeshocks, self.x)
             if lastcheck:
@@ -73,22 +72,21 @@ class Mesh:
         return [x[0] for x in shocks]
 
     def handled(self, shocks, object1, object2, x, y):
-        intersection = Point(x, y)
         if isinstance(object1, Shock) and isinstance(object2, Shock):
-            for x in shocks:
-                if x.start.equals(intersection) and isinstance(x, Shock):
+            for seg in shocks:
+                if seg.start.x == x and seg.start.y == y and isinstance(seg, Shock):
                     return True
             return False
         if (isinstance(object1, Shock) and isinstance(object2, Wall)) or (
                     isinstance(object1, Wall) and isinstance(object2, Shock)) and x <= self.endexpansion:
-            for x in shocks:
-                if x.start.equals(intersection) and isinstance(x, Shock):
+            for seg in shocks:
+                if seg.start.x == x and seg.start.y == y and isinstance(seg, Shock):
                     return True
             return False
         if (isinstance(object1, Shock) and isinstance(object2, Wall)) or (
                     isinstance(object1, Wall) and isinstance(object2, Shock)) and x > self.endexpansion:
-            for x in shocks:
-                if x.start.equals(intersection) and isinstance(x, Wall):
+            for seg in shocks:
+                if seg.start.x == x and seg.start.y == y and isinstance(seg, Wall):
                     return True
             return False
 
@@ -96,13 +94,19 @@ class Mesh:
         pairs = []
         shocks = self.sortshocks(shocks, startx)
         for i in range(len(shocks) - 1):
-            interpoint = Shock.findintersection(shocks[i].start, shocks[i + 1].start, shocks[i].angle,
-                                                shocks[i + 1].angle)
+            interpoint = Shock.findintersection(shocks[i].start, shocks[i + 1].start,
+                                                shocks[i].angle, shocks[i + 1].angle)
             if interpoint is not None:
-                if interpoint.x >= startx and shocks[i].exists(interpoint.x - epsilon) and \
-                        shocks[i + 1].exists(interpoint.x - epsilon) and not self.handled(shocks, shocks[i],
-                                                                                          shocks[i + 1], interpoint.x,
-                                                                                          interpoint.y):
+                checkx1 = interpoint.x - epsilon
+                checkx2 = checkx1
+                if checkx1 < shocks[i].start.x:
+                    checkx1 = interpoint.x
+                if checkx2 < shocks[i + 1].start.x:
+                    checkx2 = interpoint.x
+                if interpoint.x >= startx and shocks[i].exists(checkx1) and \
+                        shocks[i + 1].exists(checkx2) and not self.handled(shocks, shocks[i],
+                                                                         shocks[i + 1], interpoint.x,
+                                                                         interpoint.y):
                     pairs.append((shocks[i], shocks[i + 1], interpoint))
         return pairs
 

--- a/tests/test_helperfuncs.py
+++ b/tests/test_helperfuncs.py
@@ -1,0 +1,75 @@
+import os
+import sys
+
+os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import math
+import pytest
+
+import helperfuncs as h
+from Shock import Shock
+from Point import Point
+from Wall import Wall
+
+try:
+    from shockmesh import Mesh
+except Exception:  # missing optional deps
+    Mesh = None
+
+
+def test_calcv():
+    # expected value from reference computation
+    assert math.isclose(h.calcv(1.25, 1, 5), 97.09049671693397)
+
+
+def test_calcmach():
+    assert math.isclose(h.calcmach(1.25, 1, 10), 1.404788840263791)
+
+
+def test_calcshockpropangle():
+    val = h.calcshockpropangle(1.25, 10, 20, -5)
+    assert math.isclose(val, 65.19125750707306)
+
+
+def test_calcvmax():
+    assert h.calcvmax(1.25) == 180.0
+
+
+def test_findintersection():
+    p1 = Point(0, 0)
+    p2 = Point(1, 1)
+    inter = Shock.findintersection(p1, p2, 45, -45)
+    assert math.isclose(inter.x, 1.0) and math.isclose(inter.y, 1.0)
+
+    p3 = Point(0, 1)
+    inter = Shock.findintersection(p1, p3, 0, -45)
+    assert math.isclose(inter.x, 1.0) and math.isclose(inter.y, 0.0)
+
+
+def test_createarc():
+    start = Point(0, 0)
+    segments, endx = Wall.createarc(start, 1.0, 90, 3)
+    assert len(segments) == 4
+    assert math.isclose(endx, 4.0)
+    angles = [seg.angle for seg in segments]
+    assert angles == [0, 30.0, 60.0, 90.0]
+
+
+def test_handled_shock_intersection():
+    if Mesh is None:
+        pytest.skip("shockmesh dependencies unavailable")
+    s1 = Shock(Point(0, 0), 1, 1.4, 0, 0)
+    s2 = Shock(Point(1, 1), -1, 1.4, 0, 0)
+    mesh = Mesh(1.4, 1, [], [s1, s2], 10, 1)
+    assert mesh.handled(mesh.shocks, s1, s2, 1, 1)
+
+
+def test_handled_shock_wall():
+    if Mesh is None:
+        pytest.skip("shockmesh dependencies unavailable")
+    shock = Shock(Point(0, 0), 1, 1.4, 0, 0)
+    wall = Wall(Point(1, 0), 0)
+    s2 = Shock(Point(1, 0), 2, 1.4, 0, 0)
+    mesh = Mesh(1.4, 1, [wall], [shock, s2], 10, 1)
+    assert mesh.handled(mesh.shocks, shock, wall, 1, 0)


### PR DESCRIPTION
## Summary
- cache heavy math helpers with `lru_cache`
- streamline `Mesh.simulate` loop and intersection tracking
- add regression tests for helpers and `Mesh.handled`
- merge recent collision-detection fixes from `master`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a21a7f8f483318a95c49d7fe4e5f3