### PR TITLE
Add comprehensive test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.pytest.ini_options]
-addopts = "--cov=helperfuncs --cov-report=term-missing"
+addopts = "--cov=. --cov-report=term-missing"
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/tests/test_mesh_more.py
+++ b/tests/test_mesh_more.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import math
+
+os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Point import Point
+from Shock import Shock
+from Wall import Wall
+from shockmesh import Mesh, convertpoint
+
+
+def test_mesh_upstream_and_genwallshock():
+    w1 = Wall(Point(0, 0), 0)
+    w2 = Wall(Point(1, 0), 0)
+    mesh = Mesh(1.4, 2.0, [], [w1, w2], 2, 0)
+    vals = mesh.getupstreamvalues(w1)
+    assert math.isclose(vals[0], vals[0])  # ensure numbers returned
+    new_shock = mesh.genwallshock(w1, w2)
+    assert isinstance(new_shock, Shock)
+    assert math.isclose(new_shock.turningangle, 0)
+
+
+def test_mesh_reflect_and_getxytable_convert():
+    shock = Shock(Point(0, 0), 5, 1.4, 0, 0)
+    reflected = Mesh.reflectshock(shock, 1, 0)
+    assert reflected.turningangle == -shock.turningangle
+    w = Wall(Point(0, 0), 0)
+    mesh = Mesh(1.4, 1.0, [], [w], 1, 0)
+    table = mesh.getxytable(0, 3, 0.5)
+    assert len(table) == 3
+    x, y = convertpoint([(0, 0), (1, 1)], 0.5, 0.5, 100, 100)
+    assert math.isclose(x, 50)
+    assert math.isclose(y, 50)
+
+def test_findpairs_and_firstevent():
+    s1 = Shock(Point(0, 0), 5, 1.4, 0, 0)
+    s2 = Shock(Point(0, 1), -5, 1.4, 0, 0)
+    # Override automatically computed angles to force an intersection
+    s1.angle = 45
+    s2.angle = -45
+    mesh = Mesh(1.4, 1, [], [s1, s2], 2, 0)
+    pair = mesh.firstintersection([s1, s2], 0)
+    assert pair[0] in (s1, s2)
+    event = mesh.firstevent([s1, s2], 0)
+    assert event[0] == "intersection"
+    assert isinstance(event[1][2], Point)
+
+
+def test_handleintersection_and_area():
+    s1 = Shock(Point(0, 0), 5, 1.4, 0, 0)
+    s2 = Shock(Point(0, 1), -5, 1.4, 0, 0)
+    s1.angle = 45
+    s2.angle = -45
+    mesh = Mesh(1.4, 1, [], [s1, s2], 2, 0)
+    mesh.handleintersection(s1, s2, 1, 0.5)
+    assert len(mesh.shocks) == 4
+    assert s1.end.x == 1 and s2.end.x == 1
+    w1 = Wall(Point(0, 0), 0)
+    w2 = Wall(Point(0, 1), 0)
+    mesh = Mesh(1.4, 1, [], [w1, w2], 1, 0)
+    assert math.isclose(mesh.calcarearatio(), 1.0)
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import math
+
+os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from Point import Point
+from Shock import Shock
+from Wall import Wall
+from shockmesh import Mesh
+
+
+def test_point_distance_and_equals():
+    p1 = Point(0, 0)
+    p2 = Point(3, 4)
+    assert p1.distance(p2) == 5
+    assert not p1.equals(p2)
+    assert p2.equals(Point(3, 4))
+
+
+def test_shock_vals_and_exists_str():
+    shock = Shock(Point(0, 0), 5, 1.4, 0, 0)
+    assert shock.getupstreamvals() == [0, 0, 1.4]
+    assert shock.getdownstreamvals() == [5, 5, 1.4]
+    assert not shock.exists(-1)
+    assert shock.exists(0.1)
+    shock.end = Point(0.2, 0)
+    assert not shock.exists(1)
+    text = str(shock)
+    assert "Start" in text and "Angle" in text
+
+
+def test_shock_regions_and_newshocks():
+    s1 = Shock(Point(0, 0), 3, 1.4, 0, 0)
+    s2 = Shock(Point(1, 0), -2, 1.4, 0, 0)
+    params = Shock.calcregionparams(0, 0, 1.4, s1)
+    assert params == [3, 3, 1.4]
+    new = Shock.newshocks(s1, s2, 1, 1)
+    assert len(new) == 2
+    assert new[0].turningangle == s2.turningangle
+    assert new[1].turningangle == s1.turningangle
+
+
+def test_wall_methods_and_mesh_helpers():
+    wall = Wall(Point(0, 0), 45, Point(1, 1))
+    assert wall.propangle() == 45
+    assert wall.exists(0.5)
+    assert math.isclose(wall.getyposition(0.5), 0.5)
+    assert not wall.exists(2)
+
+    other = Wall(Point(1, 1), 45)
+    mesh = Mesh(1.4, 1, [], [wall, other], 2, 0)
+    sorted_walls = Mesh.sortshocks([wall, other], 0)
+    assert sorted_walls[0] == other
+    remaining = Mesh.removeended([wall, other], 0.5)
+    assert remaining == [wall, other]
+    wall.end = Point(0.25, 0.25)
+    remaining = Mesh.removeended([wall, other], 0.5)
+    assert remaining == [other]

--- a/tests/test_reference_cases.py
+++ b/tests/test_reference_cases.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import math
+
+os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+
+import helperfuncs as h
+from reference_cases import manual_prop_angle
+
+CASES = [
+    dict(gamma=1.4, M1=2.0, theta=0.0, delta=-5.0),
+    dict(gamma=1.4, M1=3.0, theta=0.0, delta=10.0),
+    dict(gamma=1.4, M1=2.0, theta=15.0, delta=-3.0),
+]
+
+
+@pytest.mark.parametrize("case", CASES)
+def test_reference_case_angles(case):
+    gamma = case['gamma']
+    v1 = h.calcv(gamma, 1, case['M1'])
+    theta = case['theta']
+    delta = case['delta']
+    code_angle = h.shockprop(gamma, v1, theta, delta)
+    manual_angle = manual_prop_angle(gamma, v1, theta, delta)
+    assert math.isclose(code_angle, manual_angle, rel_tol=1e-6)


### PR DESCRIPTION
## Summary
- enable coverage over entire repository
- add tests converting `reference_cases.py` examples into pytest
- introduce unit tests for Point, Shock, Wall, and Mesh classes
- add additional mesh tests for intersection handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a282e3c0483319005793e002bbaae