### PR TITLE
Fix simulation stopping condition

### DIFF
--- a/nozzlesim/mesh.py
+++ b/nozzlesim/mesh.py
@@ -85,6 +85,7 @@ class Mesh:
         while event is not None and self.x < stop:
             self.handleevent(event)
             event = self.firstevent(self.activeshocks, self.x)
+            lastcheck = self.remainingangle <= 0
             if lastcheck:
                 return
 

--- a/tests/test_simulate_stop.py
+++ b/tests/test_simulate_stop.py
@@ -1,0 +1,23 @@
+import nozzlesim.mesh as mesh_module
+
+
+class DummyMesh(mesh_module.Mesh):
+    def __init__(self):
+        # initialize with dummy values for parent
+        super().__init__(1.4, 1.0, [], [], 0, 1)
+        self.events = ["e1", "e2", "e3"]
+        self.counter = 0
+
+    def firstevent(self, shocks, startx):
+        return self.events.pop(0) if self.events else None
+
+    def handleevent(self, event):
+        self.counter += 1
+        if self.counter == 2:
+            self.remainingangle = 0
+
+
+def test_simulate_stops_when_remainingangle_zero():
+    m = DummyMesh()
+    m.simulate()
+    assert m.counter == 2


### PR DESCRIPTION
## Summary
- update Mesh.simulate to recheck remaining angle after each event
- add regression test for stopping when remaining angle hits zero

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a301026e08331b152b3454c990ef8